### PR TITLE
navbarの改善： プロジェクトメニューの表示法

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -14,7 +14,9 @@
             <%= link_to new_project_path, class: 'dropdown-item' do %>
               <%= icon("fas", "plus") %>プロジェクト
             <% end %>
-            <div class="dropdown-divider"></div>
+            <% if Project.exists? %>
+              <div class="dropdown-divider"></div>
+            <% end %>
             <% all_project.each do |project| %>
               <%= link_to project.name, project_path(project), class: "dropdown-item" %>
             <% end %>


### PR DESCRIPTION
navbar に表示しているプロジェクトメニューは、プロジェクトがない場合、新規プロジェクトメニューだけを表示するように変更する。

プロジェクト一覧と区切り線は表示しない。