### PR TITLE
根拠画面の見た目を修正。いいねの色が逆になっていたバグを修正。

### DIFF
--- a/app/assets/javascripts/likes.coffee
+++ b/app/assets/javascripts/likes.coffee
@@ -30,7 +30,7 @@ $(document).on 'ajax:success','.like_delete', (e, options) ->
 input_html = (area, create) ->
     like_url = "/likes/" + create.id
     area.attr('href', like_url)
-    area.html('<i class="far fa-heart"></i>')
+    area.html('<i class="fas fa-heart iine-color"></i>')
     area.data('method', 'delete')
     area.addClass('like_delete')
     area.removeClass('like_create')
@@ -38,7 +38,7 @@ input_html = (area, create) ->
 out_html = (area, destroy) ->
     like_url = "/alpha_comments/" + destroy.id + "/likes"
     area.attr('href', like_url)
-    area.html('<i class="fas fa-heart iine-color"></i>')
+    area.html('<i class="far fa-heart"></i>')
     area.data('method', 'post')
     area.addClass('like_create')
     area.removeClass('like_delete')

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -195,3 +195,11 @@ span.cday-style{
 .completed-color{
   background-color: #69e2ce;
 }
+
+input[type=checkbox] {
+  transform: scale(1.7);
+}
+
+.sizing-120{
+  font-size: 120%
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -52,7 +52,8 @@ module ApplicationHelper
   end
 
   def sidebar_link_item(name, path)
-    class_name = 'list-group-item list-group-item-action p-0 nav-item border'
+    class_name = 'list-group-item list-group-item-action p-0 nav-item border-bottom border-secondary'
+
     if current_page?(path)
       class_name << ' active'
     
@@ -65,5 +66,4 @@ module ApplicationHelper
       end
     end
   end
-
 end

--- a/app/views/alpha_evidences/_form.html.erb
+++ b/app/views/alpha_evidences/_form.html.erb
@@ -1,6 +1,6 @@
 <div class="container-fluid">
   <div class="row">
-    <div class="col-5">
+    <div class="col-8">
 
     <h4><i class="far fa-eye"></i> 根拠</h4>
     <%= form_for [@alpha_item, @alpha_evidence], remote: true do |form| %>
@@ -8,21 +8,29 @@
         <div class="field">
         <%= form.text_area :document, id: :alpha_evidence_document, size: "50x5" %>
         </div>
-    
-        <div class="field">
-        <%= form.check_box :completed, id: :alpha_evidence_completed %>
-        <%= form.label "完了" %>
-        </div>
+        
+        <div class="row">
 
-        <div class="actions">
-        <%= form.submit "変更する", class: "btn btn-primary" %>
+          <div class="col">
+            <div class="field ml-2">
+              <%= form.check_box :completed, id: :alpha_evidence_completed %>
+              <%= form.label "完了", {class: 'ml-1 sizing-120'}%>
+            </div>
+          </div>
+
+          <div class="col text-right">
+            <div class="actions">
+            <%= form.submit "変更する", class: "btn btn-primary" %>
+            </div>
+          </div>
+
         </div>
     <% end %>
     </div>
   </div>
 
   <div class="row">
-    <div class="col-10" id="ajax_commnet">
+    <div class="col-8" id="ajax_commnet">
       <h4 class="mt-4"><i class="far fa-comments"></i> コメント(<%= @alpha_evidence.alpha_comments.count %>)</h4>
       <% if @alpha_evidence.alpha_comments.any? %>
         <div class="container-fluied">
@@ -42,24 +50,22 @@
                           <!-- いいね記述部分　-->
                           <% if comment.like_user(current_user.id) && comment.user_id != current_user.id%>
                             <%= link_to like_path(comment.like_user(current_user.id).id), method: :delete, class: "like_delete", remote: true do %>
-                              <i class="far fa-heart"></i>
+                              <i class="fas fa-heart iine-color"></i>
                             <% end %>
                           <% elsif comment.user_id != current_user.id %>
                             <%= link_to alpha_comment_likes_path(comment), method: :post, class: "like_create", remote: true do %>
-                              <i class="fas fa-heart iine-color"></i>
+                              <i class="far fa-heart"></i>
                             <% end %>
                           <% end %>
 
                           | </span>
                           <span class="cday-style"><%= comment.how_long_ago %></span>
                         </div>
-                        <div class="col-md-1 ml-3 mt-1">
+                        <div class="col-md-1 ml-2 mt-0">
                           <% if comment.user_id == current_user.id %>
-                          <small><small>
                             <%= link_to alpha_comment_path(comment), method: :delete, data: { confirm: "削除しますか？" }, class: "command alpha_dalete_comment", remote: true do%>
-                              <i class="far fa-times-circle fa-2x fa-black"></i>
+                              <i class="far fa-times-circle fa-0.5x fa-black"></i>
                             <% end %>
-                          </small></small>
                           <% end %>
                         </div>
                       </div>
@@ -75,7 +81,7 @@
       <% end %>
       <%= form_for [@alpha_item, @alpha_evidence ,@alpha_evidence.alpha_comments.build] ,remote: true do |comment| %>
         <p class="mt-3"><%= comment.text_area :body,  cols: 50, rows: 4 %></p>
-        <p><%= comment.submit "投稿する", class: "btn btn-primary" %></p>
+        <p class="text-right"><%= comment.submit "投稿する", class: "btn btn-primary" %></p>
       <% end %>
     </div>
   </div>

--- a/app/views/alpha_states/show.html.erb
+++ b/app/views/alpha_states/show.html.erb
@@ -28,7 +28,7 @@
   <% end %>
 </div>
 
-<div class="row pt-3">
+<div class="row pt-3 pl-4">
   <div class="col-6">
     <%= render partial: "alpha_items/form", collection: @alpha_state.alpha_items, as: :state_item %>   
   </div>

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -1,4 +1,4 @@
-<nav class="col-md-2 d-none d-md-block bg-light sidebar p-0" id="side">
+<nav class="col-md-2 d-none d-md-block bg-light sidebar p-0 border-right border-secondary" id="side">
   <div class="sidebar-sticky pt-0">
     <ul class="list-group list-group-flush pi-draggable" draggable="true">
         <%= sidebar_link_item('プロジェクト詳細',  project_path(get_current_project_id)) %>


### PR DESCRIPTION
1. いいねの色を修正

1. チェックボックスの大きさを大きく変更

1. 根拠・コメントの変更ボタンの位置を調整

1. サイドバーにborderを付与し、サイドバーの境目を見やすく変更

![Screenshot from 2019-12-17 18-30-51](https://user-images.githubusercontent.com/51437553/70983057-716bed00-20fb-11ea-9f51-311602366ef9.png)
