### PR TITLE
根拠の最終更新者を表示する機能の追加

### DIFF
--- a/app/controllers/alpha_evidences_controller.rb
+++ b/app/controllers/alpha_evidences_controller.rb
@@ -56,7 +56,7 @@ class AlphaEvidencesController < ApplicationController
       # 根拠が完了だったときに、completed を false に変更する
       changed = -1
     end
-
+    @alpha_evidence.update_user = current_user.name
     success = true
     success = @alpha_evidence.update(alpha_evidence_params)
     @evidence_save = false

--- a/app/helpers/alpha_evidences_helper.rb
+++ b/app/helpers/alpha_evidences_helper.rb
@@ -1,2 +1,9 @@
 module AlphaEvidencesHelper
+    def put_update_user
+        if @alpha_evidence.update_user != nil
+            content_tag :div, class:"badge badge-primary" do
+                "最終更新者:"+@alpha_evidence.update_user
+            end
+        end
+    end
 end

--- a/app/views/alpha_evidences/_form.html.erb
+++ b/app/views/alpha_evidences/_form.html.erb
@@ -2,13 +2,21 @@
   <div class="row">
     <div class="col-8">
 
-    <h4><i class="far fa-eye"></i> 根拠</h4>
+    <div class="row">
+      <div class="col">
+        <h4><i class="far fa-eye"></i> 根拠</h4>
+      </div>
+      <div class="col text-right">
+        <%= put_update_user %>
+      </div>
+    </div>
+
     <%= form_for [@alpha_item, @alpha_evidence] do |form| %>
     
         <div class="field">
         <%= form.text_area :document, id: :alpha_evidence_document, size: "50x5" %>
         </div>
-        
+
         <div class="row">
 
           <div class="col">
@@ -18,7 +26,7 @@
               <%= form.label "完了", {class: 'ml-1 sizing-120'}%>
             <% elsif @version_list.max != @alpha_item.alpha_item_def.item_level and !@alpha_evidence.reviewed %>
               <%= form.check_box :reviewed, id: :alpha_evidence_reviewed %>
-              <%= form.label "確認", {class: 'ml-1 sizing-120'}%>
+              <%= form.label "確認", {class: 'ml-1 sizing-120'}%> 
             <% end %>
             </div>
           </div>

--- a/app/views/alpha_states/show.html.erb
+++ b/app/views/alpha_states/show.html.erb
@@ -1,21 +1,25 @@
 <div class="page-header">
-  <!--<h1><%= @alpha_state.dname %></h1>-->
-  <nav aria-label="breadcrumb">
-    <ol class="breadcrumb">
-      <li class="breadcrumb-item active" aria-current="page">
-        <%= link_to @project.get_framework_dname, project_alpha_alphas_path(@project) %>
-      </li>
-      <li class="breadcrumb-item active" aria-current="page">
-        <%= @alpha_alpha.dname %>
-      </li>
-      <li class="breadcrumb-item active" aria-current="page">
-        チェックリスト
-      </li>
-    </ol>
-  </nav>
+      <nav aria-label="breadcrumb">
+          <ol class="breadcrumb">
+            <li class="breadcrumb-item active" aria-current="page">
+              <%= link_to @project.get_framework_dname, project_alpha_alphas_path(@project) %>
+            </li>
+            <li class="breadcrumb-item active" aria-current="page">
+              <%= @alpha_alpha.dname %>
+            </li>
+            <li class="breadcrumb-item active" aria-current="page">
+              チェックリスト
+            </li>
+            <li class="ml-auto">
+              <h5 class="mb-0">
+                Level:<%= @version_list.max %>
+              </h5>
+            </li>
+          </ol>
+          
+      </nav>
 </div>
 
-<h3 class="px-2">Level:<%= @version_list.max %></h3>
 <!-- 状態のボタン -->
 <div class="row pl-2">
   <% @alpha_alpha.alpha_states.each_with_index do |alpha_state, index| %>

--- a/db/migrate/20200120100227_add_details_to_alpha_evidences.rb
+++ b/db/migrate/20200120100227_add_details_to_alpha_evidences.rb
@@ -1,5 +1,6 @@
 class AddDetailsToAlphaEvidences < ActiveRecord::Migration[5.1]
   def change
     add_column :alpha_evidences, :reviewed, :boolean, default: false
+    add_column :alpha_evidences, :update_user, :string 
   end
 end


### PR DESCRIPTION
1. 根拠の最終更新者を表示する機能の追加
![Screenshot from 2020-01-27 14-52-08](https://user-images.githubusercontent.com/51437553/73152810-a0bb4400-4114-11ea-8c07-96c007b6011c.png)
